### PR TITLE
Allow users to set start mode of app-pool

### DIFF
--- a/lib/iisconfig/app_pool.rb
+++ b/lib/iisconfig/app_pool.rb
@@ -35,6 +35,11 @@ module IISConfig
       @enable_32bit_app_on_win64 = value
     end
 
+    def start_mode(value)
+      @start_mode = value
+      @start_mode
+    end
+
     def process_model
       yield @process_model
     end
@@ -62,6 +67,9 @@ module IISConfig
       args << "/name:#{@name}"
       args << "/managedRuntimeVersion:#{@runtime_version}"
       args << "/managedPipelineMode:#{pipeline_mode}"
+      if @start_mode
+        args << "//startMode:#{@start_mode}"
+      end
       args
     end
 

--- a/lib/iisconfig/app_pool.rb
+++ b/lib/iisconfig/app_pool.rb
@@ -68,7 +68,7 @@ module IISConfig
       args << "/managedRuntimeVersion:#{@runtime_version}"
       args << "/managedPipelineMode:#{pipeline_mode}"
       if @start_mode
-        args << "//startMode:#{@start_mode}"
+        args << "/startMode:#{@start_mode}"
       end
       args
     end

--- a/test/example.rb
+++ b/test/example.rb
@@ -5,6 +5,7 @@ end
 app_pool do |p|
   p.name :MyAppPool
   p.runtime_version :'v2.0'
+  p.start_mode 'AlwaysRunning'
   p.process_model do |m|
     m.identity_type :NetworkService
     m.idle_timeout '0.00:30:00'


### PR DESCRIPTION
This allows users to configure the start mode of any created app pools