### PR TITLE
Allow configuration of autostarting applications

### DIFF
--- a/lib/iisconfig.rb
+++ b/lib/iisconfig.rb
@@ -20,11 +20,15 @@ command :execute, :e do |c|
   c.desc 'Dry run'
   c.switch :'dry-run'
 
+  c.desc 'Verbose'
+  c.switch :'verbose'
+
   c.action do |global_options, options, args|
     opts = {}
     opts[:recycle_apppools] = true if options[:'recycle-apppools']
 
     IISConfig::IISConfiguration.dry_run = true if options[:'dry-run']
+    IISConfig::IISConfiguration.verbose = true if options[:'verbose']
 
     config = IISConfig::IISConfiguration.new opts
 
@@ -37,6 +41,3 @@ command :execute, :e do |c|
     end
   end
 end
-
-
-

--- a/lib/iisconfig/application.rb
+++ b/lib/iisconfig/application.rb
@@ -15,6 +15,11 @@ module IISConfig
       @path = path
     end
 
+    def auto_start_provider(name, type)
+      @start_provider_name = name
+      @start_provider_type = type
+    end
+
     def physical_path(path)
       @physical_path = path
     end
@@ -34,6 +39,10 @@ module IISConfig
 
       app_pool = @app_pool unless @app_pool.nil?
       commands << %W{SET SITE /site.name:#{site}/#{@name} /[path='#{@path}'].applicationPool:#{app_pool}}
+
+      commands << %W{set config -section:system.applicationHost/serviceAutoStartProviders /-"[name='#{@start_provider_name}']" /commit:apphost} if @start_provider_name
+      commands << %W{set config -section:system.applicationHost/serviceAutoStartProviders /+"[name='#{@start_provider_name}',type='#{@start_provider_type}']" /commit:apphost} if @start_provider_name
+      commands << %W{set app #{site}/#{@name} /serviceAutoStartEnabled:True /serviceAutoStartProvider:#{@start_provider_name}} if @start_provider_name
 
       @virtual_directories.each do |s|
         commands += s.build_commands "#{site}/#{@name}"

--- a/lib/iisconfig/application.rb
+++ b/lib/iisconfig/application.rb
@@ -40,9 +40,11 @@ module IISConfig
       app_pool = @app_pool unless @app_pool.nil?
       commands << %W{SET SITE /site.name:#{site}/#{@name} /[path='#{@path}'].applicationPool:#{app_pool}}
 
-      commands << %W{set config -section:system.applicationHost/serviceAutoStartProviders /-"[name='#{@start_provider_name}']" /commit:apphost} if @start_provider_name
-      commands << %W{set config -section:system.applicationHost/serviceAutoStartProviders /+"[name='#{@start_provider_name}',type='#{@start_provider_type}']" /commit:apphost} if @start_provider_name
-      commands << %W{set app #{site}/#{@name} /serviceAutoStartEnabled:True /serviceAutoStartProvider:#{@start_provider_name}} if @start_provider_name
+      if @start_provider_name
+        commands << %W{set config -section:system.applicationHost/serviceAutoStartProviders /-"[name='#{@start_provider_name}']" /commit:apphost} if start_provider_exist? @start_provider_name
+        commands << %W{set config -section:system.applicationHost/serviceAutoStartProviders /+"[name='#{@start_provider_name}',type='#{@start_provider_type}']" /commit:apphost}
+        commands << %W{set app #{site}/#{@name} /serviceAutoStartEnabled:True /serviceAutoStartProvider:#{@start_provider_name}}
+      end
 
       @virtual_directories.each do |s|
         commands += s.build_commands "#{site}/#{@name}"

--- a/lib/iisconfig/configuration.rb
+++ b/lib/iisconfig/configuration.rb
@@ -9,6 +9,7 @@ module IISConfig
 
   class IISConfiguration
     @@dry_run = false
+    @@verbose = false
 
     def initialize(options = {})
       @options = {recycle_apppools: false}.merge(options)
@@ -25,6 +26,14 @@ module IISConfig
 
     def self.dry_run?
       @@dry_run
+    end
+
+    def self.verbose=verbose
+      @@verbose = verbose
+    end
+
+    def self.verbose?
+      @@verbose
     end
 
     def app_pool(&block)
@@ -46,7 +55,7 @@ module IISConfig
     def after(&block)
       @after << block
     end
-    
+
     def load(path)
       instance_eval IO.read(path), path
     end
@@ -98,4 +107,3 @@ module IISConfig
   end
 
 end
-

--- a/lib/iisconfig/iis_object.rb
+++ b/lib/iisconfig/iis_object.rb
@@ -22,6 +22,19 @@ module IISConfig
       exists
     end
 
+    def start_provider_exist?(name)
+      result = Runner.execute_command %W{ LIST CONFIG /section:serviceAutoStartProviders }
+      exists = false
+      doc = REXML::Document.new(result)
+
+      doc.each_element("//add[@name='#{name}']") do |e|
+        exists = true
+        break
+      end
+
+      exists
+    end
+
     protected
 
     def add_instance(collection, type, block)

--- a/lib/iisconfig/runner.rb
+++ b/lib/iisconfig/runner.rb
@@ -10,6 +10,7 @@ module IISConfig
 
       unless IISConfiguration.dry_run?
         result = `c:/windows/system32/inetsrv/appcmd #{args.join(' ')}"`
+        puts result if IISConfiguration.verbose?
         raise Exception.new($?.exitstatus) unless $?.success?
         result
       end

--- a/test/example.rb
+++ b/test/example.rb
@@ -24,6 +24,7 @@ app_pool do |p|
       a.name :MyApp
       a.path '/MyApp'
       a.physical_path 'c:\\temp\\MySite\\MyApp'
+      a.auto_start_provider "example", "Example.Class, Example"
 
       a.virtual_directory do |v|
         v.name :MyAppVirtualDirectory


### PR DESCRIPTION
This allows a user to configure an application to autostart as documented here:

http://docs.hangfire.io/en/latest/deployment-to-production/making-aspnet-app-always-running.html#enabling-service-auto-start

I am not sure if there is a requirement to create the `serviceAutoStartProviders` root element in the config files before this works, will test fully in the morning